### PR TITLE
Fix drawing of height data coming from Arduino boards

### DIFF
--- a/src/AppManager.cpp
+++ b/src/AppManager.cpp
@@ -101,8 +101,6 @@ void AppManager::setupShapeDisplayManagement() {
     // allocate height pixels objects and clear contents
     heightPixelsForShapeDisplay.allocate(m_serialShapeIOManager->shapeDisplaySizeX, m_serialShapeIOManager->shapeDisplaySizeY, 1);
     heightPixelsForShapeDisplay.set(0);
-    heightPixelsFromShapeDisplay.allocate(m_serialShapeIOManager->shapeDisplaySizeX, m_serialShapeIOManager->shapeDisplaySizeY, 1);
-    heightPixelsFromShapeDisplay.set(0);
 
     // allocate shape display graphics container and clear contents
    graphicsForShapeDisplay.allocate(600, 800, GL_RGBA);

--- a/src/AppManager.hpp
+++ b/src/AppManager.hpp
@@ -113,6 +113,8 @@ private:
     ofFbo graphicsForShapeDisplay;
     ofPixels colorPixels;
     ofPixels depthPixels;
+    
+    ofPixels convertHeightsToPixels(const std::vector<std::vector<unsigned char>>& heights);
 };
 
 

--- a/src/AppManager.hpp
+++ b/src/AppManager.hpp
@@ -108,7 +108,7 @@ private:
     // maybe rename to serialHeightInput()
     std::vector<std::vector<unsigned char>> heightsFromShapeDisplay;
     ofPixels heightPixelsForShapeDisplay;
-    ofPixels heightPixelsFromShapeDisplay;
+
     std::vector<std::vector<PinConfigs>> pinConfigsForShapeDisplay;
     ofFbo graphicsForShapeDisplay;
     ofPixels colorPixels;

--- a/src/Applications/Application.cpp
+++ b/src/Applications/Application.cpp
@@ -34,10 +34,13 @@ void Application::getPinConfigsForShapeDisplay(std::vector<std::vector<PinConfig
     pinConfigsForShapeDisplay = configs;
 };
 
-void Application::setHeightsFromShapeDisplayRef(const ofPixels *heights) {
-    heightsFromShapeDisplay = heights;
-    hasHeightsFromShapeDisplay = true;
-};
+/* This is deprecated and should be removed */
+/* The apps have their own reference to the shape IO manager and can get the heights from the boards themselves, they don't need an external object to do it for them. */
+//void Application::setHeightsFromShapeDisplayRef(const ofPixels *heights) {
+//    heightsFromShapeDisplay = heights;
+//    hasHeightsFromShapeDisplay = true;
+//};
+/* End deprecated*/
 
 void Application::setPixelsFromKinectRefs(const ofPixels *colorPixels, const ofPixels *depthPixels) {
     colorPixelsFromKinect = colorPixels;

--- a/src/Applications/Application.hpp
+++ b/src/Applications/Application.hpp
@@ -25,7 +25,11 @@ public:
     
     void getHeightsForShapeDisplay(ofPixels &heights);
     void getPinConfigsForShapeDisplay(std::vector<std::vector<PinConfigs>>& configs);
-    void setHeightsFromShapeDisplayRef(const ofPixels *heights);
+
+    /* This is deprecated and should be removed, apps can get heights from the shape display manager directly */
+    //void setHeightsFromShapeDisplayRef(const ofPixels *heights);
+    /* End deprecated */
+
     void setPixelsFromKinectRefs(const ofPixels *colorPixels, const ofPixels *depthPixels);
 
     virtual void update(float dt) {};
@@ -50,7 +54,9 @@ protected:
     
     ofPixels heightsForShapeDisplay;
     std::vector<std::vector<PinConfigs>> pinConfigsForShapeDisplay;
-    const ofPixels *heightsFromShapeDisplay;
+    
+    /* This is deprecated and should be removed, apps can get heights from the shape display manager directly */
+    //const ofPixels *heightsFromShapeDisplay;
     bool hasHeightsFromShapeDisplay = false;
 
     const ofPixels *colorPixelsFromKinect;

--- a/src/Applications/KinectHandWavy.cpp
+++ b/src/Applications/KinectHandWavy.cpp
@@ -121,18 +121,8 @@ void KinectHandWavy::updateHeights() {
     // Pass the current depth image to the shape display manager to get the actuated pixels.
     ofPixels livePixels = m_CustomShapeDisplayManager->cropToActiveSurface( blurredDepthImg.getPixels() );
     
-    // Process the inputs and updates the 'heightsForShapeDisplay' property accordingly.
-    for (int x = 0; x < m_CustomShapeDisplayManager->shapeDisplaySizeX; x++) {
-
-        for (int y = 0; y < m_CustomShapeDisplayManager->shapeDisplaySizeY; y++) {
-            
-            // This takes the 2 dimensional coordinates and turns them into a one dimensional index for the flattened array.
-            int flattenedIndex = heightsForShapeDisplay.getPixelIndex(x, y);
-            
-            // This takes the 1 dimensional index for the pin, and grabs the corresponding index from the uncorrected video pixel array.
-            heightsForShapeDisplay[flattenedIndex] = livePixels[flattenedIndex];
-        }
-    }
+    // Directly copy all pixels from livePixels to heightsForShapeDisplay.
+    heightsForShapeDisplay = livePixels;
 }
 
 ofxCvGrayscaleImage KinectHandWavy::getBlurredDepthImg() {

--- a/src/Applications/VideoPlayerApp.cpp
+++ b/src/Applications/VideoPlayerApp.cpp
@@ -40,17 +40,8 @@ void VideoPlayerApp::updateHeights() {
     // Pass the current video frame to the shape display manager to get the actuated pixels.
     ofPixels livePixels = m_CustomShapeDisplayManager->cropToActiveSurface(m_videoPixels);
     
-    for (int x = 0; x < m_CustomShapeDisplayManager->shapeDisplaySizeX; x++) {
-
-        for (int y = 0; y < m_CustomShapeDisplayManager->shapeDisplaySizeY; y++) {
-            
-            // This takes the 2 dimensional coordinates and turns them into a one dimensional index for the flattened array.
-            int flattenedIndex = heightsForShapeDisplay.getPixelIndex(x, y);
-            
-            // This takes the 1 dimensional index for the pin, and grabs the corresponding index from the uncorrected video pixel array.
-            heightsForShapeDisplay[flattenedIndex] = livePixels[flattenedIndex];
-        }
-    }
+    // Directly copy all pixels from livePixels to heightsForShapeDisplay.
+    heightsForShapeDisplay = livePixels;
 }
 
 void VideoPlayerApp::drawGraphicsForShapeDisplay(int x, int y, int width, int height) {

--- a/src/ShapeDisplayManagers/SerialShapeIOManager.cpp
+++ b/src/ShapeDisplayManagers/SerialShapeIOManager.cpp
@@ -115,16 +115,6 @@ void SerialShapeIOManager::sendHeightsToShapeDisplay( const std::vector<std::vec
     update();
 }
 
-// Get the actual height values on the shape display. They will be copied into
-// the destination array passed in as the argument.
-void SerialShapeIOManager::getHeightsFromShapeDisplay( const std::vector<std::vector<unsigned char>>& heights) {
-    if (!heightsFromShapeDisplayAvailable) {
-        throw ("height data from shape display is not available on " + getShapeDisplayName());
-    }
-
-    heightsFromShapeDisplay = heights;
-}
-
 // Set a single height for the display.
 //
 // Note: shape display heights will be adjusted to fit within the clipping range

--- a/src/ShapeDisplayManagers/SerialShapeIOManager.cpp
+++ b/src/ShapeDisplayManagers/SerialShapeIOManager.cpp
@@ -412,22 +412,37 @@ void SerialShapeIOManager::sendAllConfigValues() {
 // Read actual heights from the boards
 void SerialShapeIOManager::readHeightsFromBoards() {
     // receive the current heights on the shape display
+    // Iterate through all serial connections and read messages from each one.
     for (size_t i = 0; i < serialConnections.size(); i++) {
         while (serialConnections[i]->hasNewMessage()) {
+            // Make an array of 8 bytes to store the message, and read the message into it.
             unsigned char messageContent[MSG_SIZE_RECEIVE];
             serialConnections[i]->readMessage(messageContent);
+
+            // If the first byte of the message is TERM_ID_HEIGHT_RECEIVE, then the message is a height message.
             if (messageContent[0] == TERM_ID_HEIGHT_RECEIVE) {
+                // The second byte of the message is the board address, which is used to determine which board the message is from.
+                // Board addresses are 1-indexed, so subtract 1 to adjust it for zero indexing.
                 int boardAddress = messageContent[1] - 1;
+                // If the board address is valid, then the message is a height message from a board.
                 if (boardAddress >= 0 && boardAddress <= numberOfArduinos) {
+                    // Iterate through the next 6 bytes of the message, which contain the height values for the 6 pins on the board.
                     for (int j = 0; j < 6; j++) {
+                        // The height value is the third byte of the message. 
                         int height = messageContent[j + 2];
+                        // If the board inverts height values, then invert the height value.
                         if (pinBoards[boardAddress].invertHeight) {
                             height = 255 - height;
                         }
                         
+                        // Check if the height value is within the valid range of 0 to 255.
                         if (height >= 0 && height <= 255) {
+
+                            // Get the x and y coordinates of the pin on the board.
                             int x = pinBoards[boardAddress].pinCoordinates[j][0];
                             int y = pinBoards[boardAddress].pinCoordinates[j][1];
+
+                            // Store the height value in the heightsFromShapeDisplay array.
                             heightsFromShapeDisplay[x][y] = height;
                         }
                     }

--- a/src/ShapeDisplayManagers/SerialShapeIOManager.hpp
+++ b/src/ShapeDisplayManagers/SerialShapeIOManager.hpp
@@ -40,7 +40,11 @@ public:
     
     // send and receive height values
     void sendHeightsToShapeDisplay(const std::vector<std::vector<unsigned char>>& heights);
-    void getHeightsFromShapeDisplay(const std::vector<std::vector<unsigned char>>& heights);
+
+    const std::vector<std::vector<unsigned char>>& getHeightsFromShapeDisplay() const {
+        return heightsFromShapeDisplay;
+    }
+    
     void clearShapeDisplayHeights(int value=0);
 
     // setters for pin config values


### PR DESCRIPTION
This change simplifies the handling of heightsFromShapeDisplay by getting the data directly from the shape IO Manager instead of copying it to a local variable of the AppManager.

At some point the other data path stopped working, this simplification fixes that problem. Now the heights data coming from the Arduino boards is being correctly drawn on screen.

It also simplifies some app code where ofPixels data was being copied to another ofPixels object in an overly complicated way.