### PR TITLE
Optionally disable specific pins

### DIFF
--- a/src/ShapeDisplayManagers/InFormIOManager.hpp
+++ b/src/ShapeDisplayManagers/InFormIOManager.hpp
@@ -26,6 +26,11 @@ public:
         // This is a method instead of a property only to simplify the inheritance by making the superclass declaration virtual.
         return "inFORM";
     }
+
+    // specify pins to disable here, in (x, y)
+    vector<PinLocation> getDisabledPins() {
+        return {};
+    }
     
     // should pins that appear stuck be turned off at regular intervals?
     bool enableStuckPinSafetyToggle = false;

--- a/src/ShapeDisplayManagers/SerialShapeIOManager.cpp
+++ b/src/ShapeDisplayManagers/SerialShapeIOManager.cpp
@@ -218,7 +218,7 @@ void SerialShapeIOManager::clipAllHeightValuesToBeWithinRange() {
 void SerialShapeIOManager::readyDataForArduinos() {
     // set any disabled pins to 0
     for (PinLocation pinLoc : getDisabledPins()) {
-        heightsForShapeDisplay[pinLoc.x][pinLoc.y] = 0;
+        heightsForShapeDisplay[pinLoc.x][pinLoc.y] = pinHeightMin;
     }
 
     for (int i = 0; i < numberOfArduinos; i++) {

--- a/src/ShapeDisplayManagers/SerialShapeIOManager.cpp
+++ b/src/ShapeDisplayManagers/SerialShapeIOManager.cpp
@@ -6,6 +6,7 @@
 //
 
 #include "SerialShapeIOManager.hpp"
+#include "constants.h"
 
 //--------------------------------------------------------------
 //
@@ -215,6 +216,11 @@ void SerialShapeIOManager::clipAllHeightValuesToBeWithinRange() {
 // Copy data from storage in the 2D array to the corresponding arduino board
 // structures. Flip height values where needed to match the board's orientation.
 void SerialShapeIOManager::readyDataForArduinos() {
+    // set any disabled pins to 0
+    for (PinLocation pinLoc : getDisabledPins()) {
+        heightsForShapeDisplay[pinLoc.x][pinLoc.y] = 0;
+    }
+
     for (int i = 0; i < numberOfArduinos; i++) {
         for (int j = 0; j < NUM_PINS_ARDUINO; j++) {
             int x = pinBoards[i].pinCoordinates[j][0];

--- a/src/ShapeDisplayManagers/SerialShapeIOManager.hpp
+++ b/src/ShapeDisplayManagers/SerialShapeIOManager.hpp
@@ -92,6 +92,13 @@ protected:
     virtual void configureBoards() = 0;
     void printBoardConfiguration();
 
+    struct PinLocation {
+        int x;
+        int y;
+    };
+    // specific to device pin-disabling, return pin location to disable
+    virtual vector<PinLocation> getDisabledPins() {return {};}
+
     // pin height data processors
     void toggleStuckPins();
     void clipAllHeightValuesToBeWithinRange();


### PR DESCRIPTION
This change allows for individual pins to be marked as disabled, they will never move from their minimum height.

Eventually the pins might be specified in an external file like settings.xml, but for now the option is to hardcode them by x and y coordinates in the shape display manager code.