### PR TITLE
Remove ofImage scaler from Transform IO Manager

### DIFF
--- a/src/ShapeDisplayManagers/InFormIOManager.cpp
+++ b/src/ShapeDisplayManagers/InFormIOManager.cpp
@@ -132,6 +132,12 @@ ofPixels InFormIOManager::cropToActiveSurface(ofPixels fullSurface) {
     // Inform needs no cropping, but it does need to be resized to pin dimensions of the active surface.
     // NOTE video mode doesn't need resizing, so check to see if the dimensions differ before resizing.
     if (fullSurface.getWidth() != shapeDisplaySizeX || fullSurface.getHeight() != shapeDisplaySizeY) {
+        
+        // Originally we just resized directly, but for inForm there may be some quality benefit to converting to ofImage first.
+        // We're not doing this for TRANSFORM, because it messes up the escher mode video, so the original scaler is here commented out in case we decide to revert back.
+        //fullSurface.resize(shapeDisplaySizeX, shapeDisplaySizeY);
+
+        // This is the ofImage scaler, which may help smoothness? Maybe it makes a difference when working with 16 bit pixels versus 8 bit?
         // Convert to ofImage before resizing to improve quality.
         ofImage fullSurfaceIm = fullSurface;
         // Resize the image.

--- a/src/ShapeDisplayManagers/TransformIOManager.cpp
+++ b/src/ShapeDisplayManagers/TransformIOManager.cpp
@@ -144,12 +144,7 @@ ofPixels TransformIOManager::cropToActiveSurface( ofPixels fullSurface ) {
     ofPixels combinedActiveZones = combineActiveZones(fullSurface, sections);
     
     // Scale and rotate the combined active zones to match the display.
-    // First, convert to ofImage before resizing to improve quality.
-    ofImage combinedActiveZonesIm = combinedActiveZones;
-    // Resize the image.
-    combinedActiveZonesIm.resize(shapeDisplaySizeX, shapeDisplaySizeY);
-    // Convert back to ofPixels for consistency.
-    combinedActiveZones = combinedActiveZonesIm.getPixels();
+    combinedActiveZones.resize(shapeDisplaySizeX, shapeDisplaySizeY);
     
     combinedActiveZones.rotate90(2);
     


### PR DESCRIPTION
The ofImage scaling causes aliasing with the escher mode video in TRANSFORM mode. This change takes it out from the Transform IO Manager.

It still may be of benefit to inFORM (and it doesn't seem so harmful to escher mode on inFORM), so I didn't remove it from the Inform IO Manager. But I added some commentary about this history to the code in case we decide to revisit the issue.
