### PR TITLE
Add variable rain to interactive wave

### DIFF
--- a/src/AppManager.cpp
+++ b/src/AppManager.cpp
@@ -250,7 +250,7 @@ void AppManager::draw() {
 	menuHeight += 30;
 	
 	// if there isn't already a debug gui, draw some more information
-	if (!showDebugGui || currentApplication == applications["water"] || currentApplication == applications["stretchy"]) {
+	if (!showDebugGui || currentApplication == applications["waveModeContours"] || currentApplication == applications["stretchy"]) {
 		ofDrawBitmapString(currentApplication->appInstructionsText(),menuLeftCoordinate, menuHeight);
 		menuHeight += 20;
 	}

--- a/src/Applications/WaveModeContours.cpp
+++ b/src/Applications/WaveModeContours.cpp
@@ -400,6 +400,33 @@ void WaveModeContours::drawPreviewActuatedSections() {
     fbo.draw(m_kinectManager->mask);
 }
 
+// Control the raindrop ripple effect with the keyboard.
+// Uses 2 different scales for the rainDropsPerSecond value, depending on whether it is less than 1 or greater than 1.
+// The rainDropsPerSecond value is changed by 0.2 if it is less than 1, and by 1 if it is greater than 1; this is to give more options for light rain.
 void WaveModeContours::keyPressed(int Key) {
+    
+    // Look for a ']', a forward arrow key press, or a an up arrow key press to increase the rainDropsPerSecond value.
+    if (Key == 93 || Key == 57358 || Key == 57357) {
+        // If rainDropsPerSecond is less than 1, increment it by .2
+        if (rainDropsPerSecond < 1) {
+            rainDropsPerSecond += 0.2;
+        } else {
+            // Otherwise, increment it by 1
+            rainDropsPerSecond += 1;
+        } 
+        cout << "Rain Drops Per Second: " << rainDropsPerSecond << endl;  
+    }
+    
+    // Look for a '[', backward arrow key press or a down arrow key to decrease the rainDropsPerSecond value.
+    if (Key == 91 || Key == 57356 || Key == 57359) {
+        // If rainDropsPerSecond is less than or equal to, decrement it by .2
+        if (rainDropsPerSecond > 0.01 && rainDropsPerSecond <= 1) { // 0.01 to account for minor floating point errors
+            rainDropsPerSecond -= 0.2;
+        } else if (rainDropsPerSecond > 1) {
+            // Otherwise, decrement it by 1
+            rainDropsPerSecond -= 1;
+        }
+        cout << "Rain Drops Per Second: " << rainDropsPerSecond << endl;
+    }
     
 }

--- a/src/Applications/WaveModeContours.cpp
+++ b/src/Applications/WaveModeContours.cpp
@@ -28,20 +28,14 @@ void WaveModeContours::setup(){
     
     timeControl = 0;
     
-    density = new float*[cols];
-    velocity = new float*[cols];
-    wallMask = new bool*[cols];
-    previousWallMask = new bool*[cols];
+    // Allocate memory for density, velocity, wallMask, and previousWallMask vectors
+    density.resize(cols, std::vector<float>(rows, 0));
+    velocity.resize(cols, std::vector<float>(rows, 0));
+    wallMask.resize(cols, std::vector<bool>(rows, false));
+    previousWallMask.resize(cols, std::vector<bool>(rows, false));
     
     contourFinder;
     lastContourCentroids;
-    
-    for (int x = 0; x < cols; x++){
-        density[x] = new float[rows];
-        velocity[x] = new float[rows];
-        wallMask[x] = new bool[rows];
-        previousWallMask[x] = new bool[rows];
-    }
     
     friction = 0.8;
     

--- a/src/Applications/WaveModeContours.cpp
+++ b/src/Applications/WaveModeContours.cpp
@@ -415,8 +415,7 @@ void WaveModeContours::keyPressed(int Key) {
         } else {
             // Otherwise, increment it by 1
             rainDropsPerSecond += 1;
-        } 
-        cout << "Rain Drops Per Second: " << rainDropsPerSecond << endl;  
+        }
     }
     
     // Look for a '[', backward arrow key press or a down arrow key to decrease the rainDropsPerSecond value.
@@ -428,7 +427,6 @@ void WaveModeContours::keyPressed(int Key) {
             // Otherwise, decrement it by 1
             rainDropsPerSecond -= 1;
         }
-        cout << "Rain Drops Per Second: " << rainDropsPerSecond << endl;
     }
     
 }

--- a/src/Applications/WaveModeContours.cpp
+++ b/src/Applications/WaveModeContours.cpp
@@ -421,7 +421,7 @@ void WaveModeContours::keyPressed(int Key) {
     // Look for a '[', backward arrow key press or a down arrow key to decrease the rainDropsPerSecond value.
     if (Key == 91 || Key == 57356 || Key == 57359) {
         // If rainDropsPerSecond is less than or equal to, decrement it by .2
-        if (rainDropsPerSecond > 0.01 && rainDropsPerSecond <= 1) { // 0.01 to account for minor floating point errors
+        if (rainDropsPerSecond > 0.01 && rainDropsPerSecond <= 1) { // Don't go below zero, but use 0.01 instead of 0 to account for minor floating point errors
             rainDropsPerSecond -= 0.2;
         } else if (rainDropsPerSecond > 1) {
             // Otherwise, decrement it by 1

--- a/src/Applications/WaveModeContours.cpp
+++ b/src/Applications/WaveModeContours.cpp
@@ -14,6 +14,8 @@
 #include <cstdlib> // Include for rand() and srand()
 #include <ctime>   // Include for time()
 
+#include <iomanip> // Include for std::setprecision
+
 #include <algorithm>
 
 WaveModeContours::WaveModeContours(SerialShapeIOManager *theSerialShapeIOManager, KinectManagerSimple *theKinectManager) : Application(theSerialShapeIOManager) {
@@ -429,4 +431,15 @@ void WaveModeContours::keyPressed(int Key) {
         cout << "Rain Drops Per Second: " << rainDropsPerSecond << endl;
     }
     
+}
+
+string WaveModeContours::appInstructionsText() {
+    string instructions = (string) "Rainfall: \n";
+    instructions += "Use arrow or bracket keys to change rainfall.\n";
+
+    // Use stringstream to format rainDropsPerSecond to one decimal place
+    std::ostringstream stream;
+    stream << std::fixed << std::setprecision(1) << rainDropsPerSecond;
+    instructions += "Raindrops per second is " + stream.str() + "\n";
+    return instructions;
 }

--- a/src/Applications/WaveModeContours.hpp
+++ b/src/Applications/WaveModeContours.hpp
@@ -31,7 +31,10 @@ public:
     int rows;
     float friction;
     
-    int timeControl;
+    // Raindrop ripple effect parameters
+    float timeControl;
+    float rainDropsPerSecond; // Variable to control the number of raindrops per second
+    float lastRippleTime; // Timer to track the last ripple effect time
     
     int highResCols;
     int highResRows;

--- a/src/Applications/WaveModeContours.hpp
+++ b/src/Applications/WaveModeContours.hpp
@@ -74,6 +74,7 @@ public:
     std::tuple<int, int, int> heightPixelToMapColor(int Height);
     std::vector<ofPoint> lastContourCentroids;
     
+    string appInstructionsText();
     
 private:
     KinectManagerSimple* m_kinectManager;

--- a/src/Applications/WaveModeContours.hpp
+++ b/src/Applications/WaveModeContours.hpp
@@ -37,10 +37,14 @@ public:
     int highResRows;
     int highResFactor;
     
-    float **velocity;
-    float **density;
-    bool **wallMask;
-    bool **previousWallMask;
+    // velocity and density are 2d arrays that represent the state of the fluid simulation.
+    std::vector<std::vector<float>> velocity;
+    std::vector<std::vector<float>> density;
+    
+    // The wall masks are 2d arrays that mark the position of walls (detected obstacles) in the fluid simulation.
+    // A new wall mask at a given position can trigger a ripple effect in the fluid simulation.
+    std::vector<std::vector<bool>> wallMask;
+    std::vector<std::vector<bool>> previousWallMask;
     
     float **highResDensity;
     float **highResVelocity;

--- a/src/Applications/WaveModeContours.hpp
+++ b/src/Applications/WaveModeContours.hpp
@@ -36,9 +36,6 @@ public:
     float rainDropsPerSecond; // Variable to control the number of raindrops per second
     float lastRippleTime; // Timer to track the last ripple effect time
     
-    int highResCols;
-    int highResRows;
-    int highResFactor;
     
     // velocity and density are 2d arrays that represent the state of the fluid simulation.
     std::vector<std::vector<float>> velocity;
@@ -49,13 +46,9 @@ public:
     std::vector<std::vector<bool>> wallMask;
     std::vector<std::vector<bool>> previousWallMask;
     
-    float **highResDensity;
-    float **highResVelocity;
-    
     float getAdjacencyDensitySum(int x, int y);
     void solveFluid();
     
-    void solveHighResFluid();
     void updatePreviousWallMask();
     void applyRippleEffect(int x, int y);
     void handInteraction(int x, int y);


### PR DESCRIPTION
This change adds an optional "rain" effect to interactive wave mode (WaveModeContours). The rainfall rate is adjustable with keyboard controls, and the current value is display in the main app window.

The additional application text is enabled in AppManager by adding the mode to the allow list for `currentApplication->appInstructionsText()` and implementing an appInstructionsText() method in the mode. Nobody had been using this feature for a while, but it is still there and still works.

Also:
- Adds additional explanatory comments
- Changes density, velocity, wallMask, and previousWallMask from static arrays to vectors
- Removes some unused properties from the header file
