### PR TITLE
Add inFORM power supply activation and deactivation

### DIFF
--- a/src/ShapeDisplayManagers/InFormIOManager.hpp
+++ b/src/ShapeDisplayManagers/InFormIOManager.hpp
@@ -21,6 +21,9 @@ public:
     
     InFormIOManager(KinectManagerSimple* kinectRef);
     
+    // Destructor to handle power supply deactivation
+    ~InFormIOManager();
+
     // Name to identify the shape display.
     string getShapeDisplayName() {
         // This is a method instead of a property only to simplify the inheritance by making the superclass declaration virtual.
@@ -40,6 +43,14 @@ public:
 protected:
     // setup hardware-specific board configuration
     void configureBoards();
+    
+private:
+    // Serial connection for power supply control
+    ofSerial powerSupplySerial;
+
+    // Power supply control functions
+    void activatePowerSupply();
+    void deactivatePowerSupply();
 };
 
 #endif /* InFormIOManager_hpp */


### PR DESCRIPTION
Adds special handlers to the inFORM shape display manager to activate the power supply in the shape display constructor. It also deactivates the power supply in the destructor, which runs when the application closes.

The usb addresses may need to be adjusted.