### PR TITLE
Add camera device ID configuration to DisplayApp

### DIFF
--- a/src/DisplayApp.cpp
+++ b/src/DisplayApp.cpp
@@ -8,6 +8,7 @@ DisplayApp::~DisplayApp() {
 //--------------------------------------------------------------
 void DisplayApp::setup(){
 	mainApp->equationMode->publicDisplaySetup();
+    cam.setDeviceID(camDeviceId);
     cam.setup(1920, 1080);
 }
 

--- a/src/DisplayApp.hpp
+++ b/src/DisplayApp.hpp
@@ -6,7 +6,7 @@
 
 class DisplayApp : public ofBaseApp{
 public:
-    DisplayApp(int startWidth, int startHeight) : width(startWidth), height(startHeight) {}
+    DisplayApp(int startWidth, int startHeight, int camDeviceId) : width(startWidth), height(startHeight), camDeviceId(camDeviceId) {}
     ~DisplayApp();
 
 		void setup();
@@ -37,4 +37,5 @@ public:
 protected:
     int width;
     int height;
+    int camDeviceId;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@ int main( ){
 
 	bool hasPublicWindow = layoutSettings.getValue("hasPublicWindow", false);
 	bool hasProjectorWindow = layoutSettings.getValue("hasProjectorWindow", false);
+	int camDeviceId = layoutSettings.getValue("camDeviceId", 0);
 
     // create main window with specific location
 	ofGLFWWindowSettings settings;
@@ -71,7 +72,7 @@ int main( ){
     
     // seperate applications (needed for some openframeworks stuff)
     auto manager = make_shared<AppManager>();
-    auto displayApp = hasPublicWindow ? make_shared<DisplayApp>(displayWindow->getWidth(), displayWindow->getHeight()) : nullptr;
+    auto displayApp = hasPublicWindow ? make_shared<DisplayApp>(displayWindow->getWidth(), displayWindow->getHeight(), camDeviceId) : nullptr;
     auto projectorApp = hasProjectorWindow ? make_shared<ProjectorApp>(projectorWindow->getWidth(), projectorWindow->getHeight()) : nullptr;
 
     // let the windows see each other

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,7 +80,11 @@ int main( ){
     manager->displayWindow = displayWindow;
     if (hasProjectorWindow) projectorApp->mainApp = manager;
     manager->projectorWindow = projectorWindow;
-    manager->cam = &displayApp->cam;
+    
+    // Only set camera reference if public window exists
+    if (hasPublicWindow) {
+        manager->cam = &displayApp->cam;
+    }
 
     ofRunApp(mainWindow, manager);
     if (hasPublicWindow) ofRunApp(displayWindow, displayApp);


### PR DESCRIPTION
Allows specifying which camera to use via the layout settings file, rather than defaulting to the first available device.
