### PR TITLE
Fix parameter shadowing in DisplayApp constructor

### DIFF
--- a/src/DisplayApp.hpp
+++ b/src/DisplayApp.hpp
@@ -6,25 +6,26 @@
 
 class DisplayApp : public ofBaseApp{
 public:
-    DisplayApp(int startWidth, int startHeight, int camDeviceId) : width(startWidth), height(startHeight), camDeviceId(camDeviceId) {}
+    // FIX: Changed the incoming parameter to 'deviceId' to prevent shadowing
+    DisplayApp(int startWidth, int startHeight, int deviceId) : width(startWidth), height(startHeight), camDeviceId(deviceId) {}
     ~DisplayApp();
 
-		void setup();
-		void update();
-		void draw();
+    void setup();
+    void update();
+    void draw();
     void exit();
-		
-		void keyPressed(int key);
-		void keyReleased(int key);
-		void mouseMoved(int x, int y);
-		void mouseDragged(int x, int y, int button);
-		void mousePressed(int x, int y, int button);
-		void mouseReleased(int x, int y, int button);
-		void mouseEntered(int x, int y);
-		void mouseExited(int x, int y);
-		void windowResized(int w, int h);
-		void dragEvent(ofDragInfo dragInfo);
-		void gotMessage(ofMessage msg);
+        
+    void keyPressed(int key);
+    void keyReleased(int key);
+    void mouseMoved(int x, int y);
+    void mouseDragged(int x, int y, int button);
+    void mousePressed(int x, int y, int button);
+    void mouseReleased(int x, int y, int button);
+    void mouseEntered(int x, int y);
+    void mouseExited(int x, int y);
+    void windowResized(int w, int h);
+    void dragEvent(ofDragInfo dragInfo);
+    void gotMessage(ofMessage msg);
 
     // main window
     shared_ptr<AppManager> mainApp;


### PR DESCRIPTION
Fixes #49

What changed:

Renamed the incoming parameter camDeviceId to deviceId in the DisplayApp constructor.

Why:

This prevents the parameter from shadowing the member variable camDeviceId declared at the bottom of DisplayApp.hpp.